### PR TITLE
Fix server entry point build error

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import createApp from '../server/index.js';
+import createApp from '../server/index';
 
 let appInstance: any = null;
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,13 +1,18 @@
-// Vercel serverless function entry point
-import createApp from '../server/index.ts';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import createApp from '../server/index.js';
 
 let appInstance: any = null;
 
-export default async function handler(req: any, res: any) {
-  if (!appInstance) {
-    const { app } = await createApp();
-    appInstance = app;
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    if (!appInstance) {
+      const { app } = await createApp();
+      appInstance = app;
+    }
+    
+    return appInstance(req, res);
+  } catch (error) {
+    console.error('API Error:', error);
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
-  
-  return appInstance(req, res);
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build --config vite.config.simple.ts",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,17 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "vite build --config vite.config.simple.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+  "buildCommand": "vite build --config vite.config.simple.ts",
   "outputDirectory": "dist",
+  "functions": {
+    "api/**/*.ts": {
+      "runtime": "nodejs20.x"
+    }
+  },
   "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
     {
       "source": "/(.*)",
       "destination": "/index.html"


### PR DESCRIPTION
Fix Vercel build error by updating build commands and configuring serverless functions.

The previous build configuration in `package.json` and `vercel.json` attempted to bundle the server entry point (`server/index.ts`) with `esbuild` while simultaneously marking it as external, leading to a build error. This PR removes the conflicting `esbuild` command, configures Vercel to correctly handle API routes as serverless functions, and updates the API entry point for Vercel compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fe95e65-4b98-4ddb-844d-c99bb38489cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fe95e65-4b98-4ddb-844d-c99bb38489cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

