### PR TITLE
Validate function runtime versions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "outputDirectory": "dist",
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs22.x"
     }
   },
   "rewrites": [


### PR DESCRIPTION
Update Node.js runtime to 22.x in `vercel.json` to resolve runtime version error.

Vercel has updated its runtime specifications, requiring a more specific version format. Node.js 22.x is now the default and fully supported version, while Node.js 20.x may have compatibility issues. This change ensures compatibility and uses the latest supported runtime.

---
<a href="https://cursor.com/background-agent?bcId=bc-86e08818-7cc9-40ca-85aa-12d53a5ffab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86e08818-7cc9-40ca-85aa-12d53a5ffab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

