### PR TITLE
Add required meta tags for Farcaster previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,9 @@
     <meta name="description" content="Real-time crypto news, market data, and Base ecosystem tracking" />
     
     <!-- Farcaster Mini App Meta Tags -->
-    <meta property="fc:frame" content="vNext" />
-    <meta property="fc:frame:image" content="https://based-news-eight.vercel.app/screenshot1.png" />
-    <meta property="fc:frame:button:1" content="View Latest News" />
-    <meta property="fc:frame:button:1:action" content="link" />
-    <meta property="fc:frame:button:1:target" content="https://based-news-eight.vercel.app" />
+    <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_miniapp","url":"https://based-news-eight.vercel.app","name":"BasedNews","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
+    <!-- For backward compatibility -->
+    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_frame","url":"https://based-news-eight.vercel.app","name":"BasedNews","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
     
     <!-- Enhanced Open Graph Meta Tags for Farcaster URL Embeds -->
     <meta property="og:title" content="BasedNews - Base Ecosystem News" />

--- a/public/minimal.html
+++ b/public/minimal.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BasedNews - Minimal Test</title>
+    
+    <!-- Farcaster Mini App Meta Tags -->
+    <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_miniapp","url":"https://based-news-eight.vercel.app/minimal.html","name":"BasedNews Minimal","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
+    <!-- For backward compatibility -->
+    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_frame","url":"https://based-news-eight.vercel.app/minimal.html","name":"BasedNews Minimal","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
     <style>
         body {
             font-family: system-ui, sans-serif;

--- a/public/simple.html
+++ b/public/simple.html
@@ -6,11 +6,9 @@
     <title>BasedNews - Simple Mini App</title>
     
     <!-- Farcaster Mini App Meta Tags -->
-    <meta property="fc:frame" content="vNext" />
-    <meta property="fc:frame:image" content="https://based-news-eight.vercel.app/hero.svg" />
-    <meta property="fc:frame:button:1" content="View Latest News" />
-    <meta property="fc:frame:button:1:action" content="link" />
-    <meta property="fc:frame:button:1:target" content="https://based-news-eight.vercel.app/simple.html" />
+    <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_miniapp","url":"https://based-news-eight.vercel.app/simple.html","name":"BasedNews Simple","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
+    <!-- For backward compatibility -->
+    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://based-news-eight.vercel.app/screenshot1.png","button":{"title":"Open BasedNews","action":{"type":"launch_frame","url":"https://based-news-eight.vercel.app/simple.html","name":"BasedNews Simple","splashImageUrl":"https://based-news-eight.vercel.app/splash.svg","splashBackgroundColor":"#0052ff"}}}' />
     
     <style>
         body {


### PR DESCRIPTION
Update Farcaster meta tags to the new `fc:miniapp` and `fc:frame` JSON format across all HTML files.

The previous meta tags were using an outdated format, causing issues with Farcaster SDK and preview tools. This update ensures compliance with the latest Farcaster specification for proper rendering and sharing.

---
<a href="https://cursor.com/background-agent?bcId=bc-777a9cbd-2f46-4581-a0a6-124bbc11b29c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-777a9cbd-2f46-4581-a0a6-124bbc11b29c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

