### PR TITLE
Configure base builder manifest section

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "vite build --config vite.config.simple.ts",
   "outputDirectory": "dist",
-  "redirects": [
-    {
-      "source": "/.well-known/farcaster.json",
-      "destination": "https://api.farcaster.xyz/miniapps/hosted-manifest/0198a1ad-1598-d9af-0c7c-5086106d7ce0",
-      "statusCode": 307
-    }
-  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Remove `/.well-known/farcaster.json` redirect in `vercel.json` to serve the local manifest with the `baseBuilder` section.

The existing `farcaster.json` in the `.well-known` directory correctly included the `baseBuilder.allowedAddresses` entry. However, Vercel's configuration was redirecting requests for `/.well-known/farcaster.json` to an external, hosted manifest that lacked this crucial section, leading to the "missing baseBuilder section in manifest" error. By removing this redirect, the local, correct manifest will now be served.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ed8c033-de5a-4901-acca-6b1464ca01b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ed8c033-de5a-4901-acca-6b1464ca01b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

